### PR TITLE
신고리뷰 수용/기각 처리에 관한 컨트롤러 서비스 dto 설계 분리 및 추가

### DIFF
--- a/src/main/java/shop/mtcoding/finalproject/config/dummy/DevInit.java
+++ b/src/main/java/shop/mtcoding/finalproject/config/dummy/DevInit.java
@@ -135,6 +135,7 @@ public class DevInit extends DummyEntity {
                         OrderDetail orderDetail14 = orderDetailRepository.save(newOrderDetail(order12, menu10));
                         OrderDetail orderDetail15 = orderDetailRepository.save(newOrderDetail(order13, menu11));
                         CeoReview ceoReview = ceoReviewRepository.save(newCeoReview(store1, order1));
+                        CeoReview ceoReview2 = ceoReviewRepository.save(newCeoReview(store1, order2));
                         CustomerReview customerReview = customerReviewRepository
                                         .save(newCustomerReview(jinsa, order1, store1, ceoReview, 5.0));
                         CustomerReview customerReview2 = customerReviewRepository
@@ -149,7 +150,7 @@ public class DevInit extends DummyEntity {
                         ReportReview reportReview1 = reportReviewRepository
                                         .save(newReportReview(ssar, customerReview, ceoReview));
                         ReportReview reportReview2 = reportReviewRepository
-                                        .save(newReportReview(jinsa, customerReview2, ceoReview));
+                                        .save(newReportReview(jinsa, customerReview2, ceoReview2));
                 };
         }
 }

--- a/src/main/java/shop/mtcoding/finalproject/domain/reportReview/ReportReview.java
+++ b/src/main/java/shop/mtcoding/finalproject/domain/reportReview/ReportReview.java
@@ -13,6 +13,8 @@ import javax.persistence.Id;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
+import org.springframework.beans.propertyeditors.CustomDateEditor;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,6 +25,7 @@ import shop.mtcoding.finalproject.domain.ceoReview.CeoReview;
 import shop.mtcoding.finalproject.domain.customerReview.CustomerReview;
 import shop.mtcoding.finalproject.domain.user.User;
 import shop.mtcoding.finalproject.dto.reportReview.ReportReviewReqDto.ResolveReportReviewReqDto;
+import shop.mtcoding.finalproject.util.CustomDateUtil;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
@@ -54,11 +57,15 @@ public class ReportReview extends AudingTime {
     private boolean isResolve;
 
     @Column(nullable = true)
+    private boolean isAccept;
+
+    @Column(nullable = true)
     private LocalDateTime resolvedTime;
 
     @Builder
     public ReportReview(Long id, User user, CustomerReview customerReview, CeoReview ceoReview, ReportReasonEnum reason,
-            String adminComment, boolean isResolve, LocalDateTime resolvedTime, LocalDateTime createdAt) {
+            String adminComment, boolean isResolve, boolean isAccept, LocalDateTime resolvedTime,
+            LocalDateTime createdAt) {
         this.id = id;
         this.user = user;
         this.customerReview = customerReview;
@@ -66,14 +73,23 @@ public class ReportReview extends AudingTime {
         this.reason = reason;
         this.adminComment = adminComment;
         this.isResolve = isResolve;
+        this.isAccept = isAccept;
         this.resolvedTime = resolvedTime;
         this.createdAt = createdAt;
     }
 
-    public void resolve(ResolveReportReviewReqDto resolveReportReviewReqDto) {
+    public void acceptResolve(ResolveReportReviewReqDto resolveReportReviewReqDto) {
         this.adminComment = resolveReportReviewReqDto.getAdminComment();
-        this.resolvedTime = createdAt;
         this.isResolve = true;
+        this.isAccept = true;
+        this.resolvedTime = createdAt;
+    }
+
+    public void refuseResolve(ResolveReportReviewReqDto resolveReportReviewReqDto) {
+        this.adminComment = resolveReportReviewReqDto.getAdminComment();
+        this.isResolve = true;
+        this.isAccept = false;
+        this.resolvedTime = createdAt;
     }
 
 }

--- a/src/main/java/shop/mtcoding/finalproject/dto/reportReview/ReportReviewRespDto.java
+++ b/src/main/java/shop/mtcoding/finalproject/dto/reportReview/ReportReviewRespDto.java
@@ -13,15 +13,33 @@ public class ReportReviewRespDto {
 
     @Getter
     @Setter
-    public static class ResolveReportReviewRespDto {
+    public static class ResolveRefuseReportReviewRespDto {
         private String adminComment;
         private boolean isResolve;
         private String resolvedTime;
+        private boolean isAccept;
 
-        public ResolveReportReviewRespDto(ReportReview reportReviewPS) {
+        public ResolveRefuseReportReviewRespDto(ReportReview reportReviewPS) {
             this.adminComment = reportReviewPS.getAdminComment();
             this.isResolve = reportReviewPS.isResolve();
-            this.resolvedTime = CustomDateUtil.toStringFormat(reportReviewPS.getResolvedTime());
+            this.resolvedTime = CustomDateUtil.toStringFormat(reportReviewPS.getCreatedAt());
+            this.isAccept = reportReviewPS.isAccept();
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class ResolveAcceptReportReviewRespDto {
+        private String adminComment;
+        private boolean isResolve;
+        private String resolvedTime;
+        private boolean isAccept;
+
+        public ResolveAcceptReportReviewRespDto(ReportReview reportReviewPS) {
+            this.adminComment = reportReviewPS.getAdminComment();
+            this.isResolve = reportReviewPS.isResolve();
+            this.resolvedTime = CustomDateUtil.toStringFormat(reportReviewPS.getCreatedAt());
+            this.isAccept = reportReviewPS.isAccept();
         }
     }
 

--- a/src/main/java/shop/mtcoding/finalproject/service/ReportReviewService.java
+++ b/src/main/java/shop/mtcoding/finalproject/service/ReportReviewService.java
@@ -31,7 +31,8 @@ import shop.mtcoding.finalproject.dto.reportReview.ReportReviewReqDto.InsertRepo
 import shop.mtcoding.finalproject.dto.reportReview.ReportReviewReqDto.ResolveReportReviewReqDto;
 import shop.mtcoding.finalproject.dto.reportReview.ReportReviewRespDto.DetailReportReviewRespDto;
 import shop.mtcoding.finalproject.dto.reportReview.ReportReviewRespDto.ReportReviewListRespDto;
-import shop.mtcoding.finalproject.dto.reportReview.ReportReviewRespDto.ResolveReportReviewRespDto;
+import shop.mtcoding.finalproject.dto.reportReview.ReportReviewRespDto.ResolveAcceptReportReviewRespDto;
+import shop.mtcoding.finalproject.dto.reportReview.ReportReviewRespDto.ResolveRefuseReportReviewRespDto;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -41,22 +42,45 @@ public class ReportReviewService {
     private final Logger log = LoggerFactory.getLogger(getClass());
     private final ReportReviewRepository reportReviewRepository;
     private final CustomerReviewRepository customerReviewRepository;
-    private final CeoReviewRepository ceoReviewRepository;
     private final UserRepository userRepository;
     private final StoreRepository storeRepository;
     private final ReportReviewRepositoryQuery reportRepositoryQuery;
 
     /* 성진 작업 시작 */
 
-    public ResolveReportReviewRespDto resolveReportReview(ResolveReportReviewReqDto resolveReportReviewReqDto,
+    @Transactional
+    public ResolveRefuseReportReviewRespDto resolveRefuseReportReview(
+            ResolveReportReviewReqDto resolveReportReviewReqDto,
             Long reportReviewId) {
         // 1. 해당 신고 리뷰가 존재하는지 체크
         ReportReview reportReviewPS = reportReviewRepository.findById(reportReviewId)
                 .orElseThrow(() -> new CustomApiException("신고 리뷰가 없습니다", HttpStatus.BAD_REQUEST));
         // 2. 해당 신고 리뷰 처분
-        reportReviewPS.resolve(resolveReportReviewReqDto);
+        reportReviewPS.refuseResolve(resolveReportReviewReqDto);
+        reportReviewRepository.save(reportReviewPS);
         // 3. DTO 응답
-        ResolveReportReviewRespDto resolveReportReviewRespDto = new ResolveReportReviewRespDto(reportReviewPS);
+        ResolveRefuseReportReviewRespDto resolveReportReviewRespDto = new ResolveRefuseReportReviewRespDto(
+                reportReviewPS);
+        try {
+            return resolveReportReviewRespDto;
+        } catch (NoResultException e) {
+            return null;
+        }
+    }
+
+    @Transactional
+    public ResolveAcceptReportReviewRespDto resolveAcceptReportReview(
+            ResolveReportReviewReqDto resolveReportReviewReqDto,
+            Long reportReviewId) {
+        // 1. 해당 신고 리뷰가 존재하는지 체크
+        ReportReview reportReviewPS = reportReviewRepository.findById(reportReviewId)
+                .orElseThrow(() -> new CustomApiException("신고 리뷰가 없습니다", HttpStatus.BAD_REQUEST));
+        // 2. 해당 신고 리뷰 처분
+        reportReviewPS.acceptResolve(resolveReportReviewReqDto);
+        reportReviewRepository.save(reportReviewPS);
+        // 3. DTO 응답
+        ResolveAcceptReportReviewRespDto resolveReportReviewRespDto = new ResolveAcceptReportReviewRespDto(
+                reportReviewPS);
         try {
             return resolveReportReviewRespDto;
         } catch (NoResultException e) {

--- a/src/main/java/shop/mtcoding/finalproject/web/ReportReviewController.java
+++ b/src/main/java/shop/mtcoding/finalproject/web/ReportReviewController.java
@@ -1,7 +1,5 @@
 package shop.mtcoding.finalproject.web;
 
-import java.util.List;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -16,11 +14,11 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 import shop.mtcoding.finalproject.config.auth.LoginUser;
 import shop.mtcoding.finalproject.dto.ResponseDto;
-import shop.mtcoding.finalproject.dto.reportReview.ReportCeoReviewRespDto;
 import shop.mtcoding.finalproject.dto.reportReview.ReportReviewReqDto.InsertReportReviewReqDto;
 import shop.mtcoding.finalproject.dto.reportReview.ReportReviewReqDto.ResolveReportReviewReqDto;
 import shop.mtcoding.finalproject.dto.reportReview.ReportReviewRespDto.DetailReportReviewRespDto;
-import shop.mtcoding.finalproject.dto.reportReview.ReportReviewRespDto.ResolveReportReviewRespDto;
+import shop.mtcoding.finalproject.dto.reportReview.ReportReviewRespDto.ResolveAcceptReportReviewRespDto;
+import shop.mtcoding.finalproject.dto.reportReview.ReportReviewRespDto.ResolveRefuseReportReviewRespDto;
 import shop.mtcoding.finalproject.service.ReportReviewService;
 
 @RequiredArgsConstructor
@@ -32,12 +30,20 @@ public class ReportReviewController {
 
     /* 성진 작업 시작@ */
 
-    @PutMapping("/admin/review/{reportReviewId}/resolve")
-    public ResponseEntity<?> resolveReportReview(@RequestBody ResolveReportReviewReqDto resolveReportReviewReqDto,
+    @PutMapping("/admin/review/{reportReviewId}/refuse")
+    public ResponseEntity<?> resolveRefuseReportReview(@RequestBody ResolveReportReviewReqDto resolveReportReviewReqDto,
             @PathVariable Long reportReviewId) {
-        ResolveReportReviewRespDto resolveReportReviewRespDto = reportReviewService
-                .resolveReportReview(resolveReportReviewReqDto, reportReviewId);
-        return new ResponseEntity<>(new ResponseDto<>(1, "신고리뷰 처리하기 기능 성공", resolveReportReviewRespDto), HttpStatus.OK);
+        ResolveRefuseReportReviewRespDto resolveReportReviewRespDto = reportReviewService
+                .resolveRefuseReportReview(resolveReportReviewReqDto, reportReviewId);
+        return new ResponseEntity<>(new ResponseDto<>(1, "신고리뷰 기각하기 기능 성공", resolveReportReviewRespDto), HttpStatus.OK);
+    }
+
+    @PutMapping("/admin/review/{reportReviewId}/accept")
+    public ResponseEntity<?> resolveAcceptReportReview(@RequestBody ResolveReportReviewReqDto resolveReportReviewReqDto,
+            @PathVariable Long reportReviewId) {
+        ResolveAcceptReportReviewRespDto resolveReportReviewRespDto = reportReviewService
+                .resolveAcceptReportReview(resolveReportReviewReqDto, reportReviewId);
+        return new ResponseEntity<>(new ResponseDto<>(1, "신고리뷰 수용하기 기능 성공", resolveReportReviewRespDto), HttpStatus.OK);
     }
 
     @GetMapping("/admin/review/{reportReviewId}/report/detail")

--- a/src/test/java/shop/mtcoding/finalproject/web/ReportReviewControllerTest.java
+++ b/src/test/java/shop/mtcoding/finalproject/web/ReportReviewControllerTest.java
@@ -144,7 +144,7 @@ public class ReportReviewControllerTest extends DummyEntity {
 
         @WithUserDetails(value = "admin", setupBefore = TestExecutionEvent.TEST_EXECUTION)
         @Test
-        public void resolveReportReview_test() throws Exception {
+        public void resolveRefuseReportReview_test() throws Exception {
                 // given
                 Long reportReviewId = 1L;
                 ResolveReportReviewReqDto resolveReportReviewReqDto = new ResolveReportReviewReqDto();
@@ -155,7 +155,7 @@ public class ReportReviewControllerTest extends DummyEntity {
 
                 // when
                 ResultActions resultActions = mvc
-                                .perform(put("/api/admin/review/" + reportReviewId + "/resolve").content(requestBody)
+                                .perform(put("/api/admin/review/" + reportReviewId + "/refuse").content(requestBody)
                                                 .contentType(APPLICATION_JSON_UTF8));
                 String responseBody = resultActions.andReturn().getResponse().getContentAsString();
                 System.out.println("테스트 : " + responseBody);
@@ -163,7 +163,31 @@ public class ReportReviewControllerTest extends DummyEntity {
                 // // then
                 resultActions.andExpect(status().isOk());
                 resultActions.andExpect(jsonPath("$.data.adminComment").value("쌍방 욕설로 인한 기각처리"));
-                resultActions.andExpect(jsonPath("$.data.resolve").value(true));
+                resultActions.andExpect(jsonPath("$.data.accept").value(false));
+        }
+
+        @WithUserDetails(value = "admin", setupBefore = TestExecutionEvent.TEST_EXECUTION)
+        @Test
+        public void resolveAcceptReportReview_test() throws Exception {
+                // given
+                Long reportReviewId = 1L;
+                ResolveReportReviewReqDto resolveReportReviewReqDto = new ResolveReportReviewReqDto();
+                resolveReportReviewReqDto.setAdminComment("쌍방 욕설로 인한 기각처리");
+
+                String requestBody = om.writeValueAsString(resolveReportReviewReqDto);
+                System.out.println("테스트 : " + requestBody);
+
+                // when
+                ResultActions resultActions = mvc
+                                .perform(put("/api/admin/review/" + reportReviewId + "/accept").content(requestBody)
+                                                .contentType(APPLICATION_JSON_UTF8));
+                String responseBody = resultActions.andReturn().getResponse().getContentAsString();
+                System.out.println("테스트 : " + responseBody);
+
+                // // then
+                resultActions.andExpect(status().isOk());
+                resultActions.andExpect(jsonPath("$.data.adminComment").value("쌍방 욕설로 인한 기각처리"));
+                resultActions.andExpect(jsonPath("$.data.accept").value(true));
         }
 
         @WithUserDetails(value = "admin", setupBefore = TestExecutionEvent.TEST_EXECUTION)


### PR DESCRIPTION
1. 신고리뷰 처리에 신고리뷰를 수용할 것인지 기각할 것인지에 대한 기능이 분리되어야했음
2. 컨트롤러 서비스 dto Junit 코드 새로 작성 및 더미데이터 추가